### PR TITLE
adjusting plugin for Moodle3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,25 +20,10 @@ addons:
  firefox: "47.0.1"
  postgresql: "9.4"
 
-env:
-  global:
-  - IGNORE_PATHS=amd/build BEHAT=yes
-  matrix:
-  - DB=pgsql MOODLE_BRANCH=MOODLE_33_STABLE
-  - DB=pgsql MOODLE_BRANCH=MOODLE_34_STABLE
-  - DB=pgsql MOODLE_BRANCH=MOODLE_35_STABLE
-  - DB=pgsql MOODLE_BRANCH=master
-  - DB=mysqli MOODLE_BRANCH=MOODLE_33_STABLE
-  - DB=mysqli MOODLE_BRANCH=MOODLE_34_STABLE
-  - DB=mysqli MOODLE_BRANCH=MOODLE_35_STABLE
-  - DB=mysqli MOODLE_BRANCH=master
-
 matrix:
-  allow_failures:
-  - DB=pgsql MOODLE_BRANCH=MOODLE_31_STABLE
-  - DB=mysqli MOODLE_BRANCH=MOODLE_31_STABLE
-  - DB=pgsql MOODLE_BRANCH=master
-  - DB=mysqli MOODLE_BRANCH=master
+  #allow_failures:
+  #- env: DB=pgsql MOODLE_BRANCH=master
+  #- env: DB=mysqli MOODLE_BRANCH=master
   exclude:
     - php: 5.6
       env: DB=pgsql MOODLE_BRANCH=master
@@ -53,6 +38,21 @@ matrix:
     - php: 5.6
       env: DB=mysqli MOODLE_BRANCH=MOODLE_35_STABLE
   fast_finish: true
+
+env:
+  global:
+  - IGNORE_PATHS=amd/build BEHAT=yes
+  matrix:
+  - DB=pgsql MOODLE_BRANCH=MOODLE_33_STABLE
+  - DB=pgsql MOODLE_BRANCH=MOODLE_34_STABLE
+  - DB=pgsql MOODLE_BRANCH=MOODLE_35_STABLE
+  #- DB=pgsql MOODLE_BRANCH=MOODLE_36_STABLE
+  - DB=pgsql MOODLE_BRANCH=master
+  - DB=mysqli MOODLE_BRANCH=MOODLE_33_STABLE
+  - DB=mysqli MOODLE_BRANCH=MOODLE_34_STABLE
+  - DB=mysqli MOODLE_BRANCH=MOODLE_35_STABLE
+  #- DB=mysqli MOODLE_BRANCH=MOODLE_36_STABLE
+  - DB=mysqli MOODLE_BRANCH=master
 
 before_install:
   - phpenv config-rm xdebug.ini
@@ -80,6 +80,13 @@ jobs:
       # - moodle-plugin-ci mustache
       - moodle-plugin-ci grunt
       - moodle-plugin-ci validate
+    # Smaller build matrix for development builds
+    - stage: develop
+      php: 7.1
+      env: DB=mysqli MOODLE_BRANCH=MOODLE_35_STABLE
+      script:
+      - moodle-plugin-ci phpunit --coverage-clover
+      - moodle-plugin-ci behat
 
 # Unit tests and behat tests against full matrix.
 script:
@@ -89,4 +96,7 @@ after_success:
   - bash <(curl -s https://codecov.io/bash)
 stages:
   - static
-  - test
+  - name: develop
+    if: branch != master AND (type != pull_request OR head_branch != master) AND (tag IS blank)
+  - name: test
+    if: branch = master OR (type = pull_request AND head_branch = master) OR (tag IS present)

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ env:
   - DB=pgsql MOODLE_BRANCH=master
   - DB=mysqli MOODLE_BRANCH=MOODLE_33_STABLE
   - DB=mysqli MOODLE_BRANCH=MOODLE_34_STABLE
+  - DB=mysqli MOODLE_BRANCH=MOODLE_35_STABLE
   - DB=mysqli MOODLE_BRANCH=master
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,18 @@ addons:
  firefox: "47.0.1"
  postgresql: "9.3"
 
+env:
+  global:
+  - IGNORE_PATHS=amd/build BEHAT=yes
+  matrix:
+  - DB=pgsql MOODLE_BRANCH=MOODLE_33_STABLE
+  - DB=pgsql MOODLE_BRANCH=MOODLE_34_STABLE
+  - DB=pgsql MOODLE_BRANCH=MOODLE_35_STABLE
+  - DB=pgsql MOODLE_BRANCH=master
+  - DB=mysqli MOODLE_BRANCH=MOODLE_33_STABLE
+  - DB=mysqli MOODLE_BRANCH=MOODLE_34_STABLE
+  - DB=mysqli MOODLE_BRANCH=master
+
 matrix:
   allow_failures:
   - DB=pgsql MOODLE_BRANCH=MOODLE_31_STABLE
@@ -40,18 +52,6 @@ matrix:
     - php: 5.6
       env: DB=mysqli MOODLE_BRANCH=MOODLE_35_STABLE
   fast_finish: true
-
-env:
- global:
-  - IGNORE_PATHS=amd/build BEHAT=yes
- matrix:
-  - DB=pgsql MOODLE_BRANCH=MOODLE_33_STABLE
-  - DB=pgsql MOODLE_BRANCH=MOODLE_34_STABLE
-  - DB=pgsql MOODLE_BRANCH=MOODLE_35_STABLE
-  - DB=pgsql MOODLE_BRANCH=master
-  - DB=mysqli MOODLE_BRANCH=MOODLE_33_STABLE
-  - DB=mysqli MOODLE_BRANCH=MOODLE_34_STABLE
-  - DB=mysqli MOODLE_BRANCH=master
 
 before_install:
   - phpenv config-rm xdebug.ini
@@ -79,13 +79,7 @@ jobs:
       # - moodle-plugin-ci mustache
       - moodle-plugin-ci grunt
       - moodle-plugin-ci validate
-    # Smaller build matrix for development builds
-    - stage: develop
-      php: 7.1
-      env: DB=mysqli MOODLE_BRANCH=MOODLE_35_STABLE
-      script:
-      - moodle-plugin-ci phpunit --coverage-clover
-      - moodle-plugin-ci behat
+
 # Unit tests and behat tests against full matrix.
 script:
   - moodle-plugin-ci phpunit --coverage-clover
@@ -94,7 +88,4 @@ after_success:
   - bash <(curl -s https://codecov.io/bash)
 stages:
   - static
-  - name: develop
-    if: branch != master AND (type != pull_request OR head_branch != master) AND (tag IS blank)
-  - name: test
-    if: branch = master OR (type = pull_request AND head_branch = master) OR (tag IS present)
+  - test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 sudo: required
-dist: precise
+dist: trusty
 
 notifications:
   email: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,10 @@ matrix:
       env: DB=pgsql MOODLE_BRANCH=MOODLE_34_STABLE
     - php: 5.6
       env: DB=mysqli MOODLE_BRANCH=MOODLE_34_STABLE
+    - php: 5.6
+      env: DB=pgsql MOODLE_BRANCH=MOODLE_35_STABLE
+    - php: 5.6
+      env: DB=mysqli MOODLE_BRANCH=MOODLE_35_STABLE
   fast_finish: true
 
 env:
@@ -43,6 +47,7 @@ env:
  matrix:
   - DB=pgsql MOODLE_BRANCH=MOODLE_33_STABLE
   - DB=pgsql MOODLE_BRANCH=MOODLE_34_STABLE
+  - DB=pgsql MOODLE_BRANCH=MOODLE_35_STABLE
   - DB=pgsql MOODLE_BRANCH=master
   - DB=mysqli MOODLE_BRANCH=MOODLE_33_STABLE
   - DB=mysqli MOODLE_BRANCH=MOODLE_34_STABLE
@@ -64,7 +69,7 @@ jobs:
     # Prechecks against latest Moodle stable only.
     - stage: static
       php: 7.1
-      env: DB=mysqli MOODLE_BRANCH=MOODLE_33_STABLE
+      env: DB=mysqli MOODLE_BRANCH=MOODLE_35_STABLE
       script:
       - moodle-plugin-ci phplint
       # - moodle-plugin-ci phpcpd
@@ -77,7 +82,7 @@ jobs:
     # Smaller build matrix for development builds
     - stage: develop
       php: 7.1
-      env: DB=mysqli MOODLE_BRANCH=MOODLE_33_STABLE
+      env: DB=mysqli MOODLE_BRANCH=MOODLE_35_STABLE
       script:
       - moodle-plugin-ci phpunit --coverage-clover
       - moodle-plugin-ci behat

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ php:
 
 addons:
  firefox: "47.0.1"
- postgresql: "9.3"
+ postgresql: "9.4"
 
 env:
   global:

--- a/block_groups.php
+++ b/block_groups.php
@@ -14,9 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-defined('MOODLE_INTERNAL') || die();
-
-require_once($CFG->dirroot.'/blocks/groups/locallib.php');
 /**
  * The File for the block groups class.
  *
@@ -26,6 +23,10 @@ require_once($CFG->dirroot.'/blocks/groups/locallib.php');
  * @copyright 2016/17 N Herrmann
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
+defined('MOODLE_INTERNAL') || die();
+
+require_once($CFG->dirroot.'/blocks/groups/locallib.php');
+
 /**
  * The block_group class
  *

--- a/block_groups.php
+++ b/block_groups.php
@@ -98,7 +98,7 @@ class block_groups extends block_base
         // Array to save all groupings.
         $allgroupings = groups_get_all_groupings($courseid);
         $content = '';
-        /* @var $renderer block_groups_renderer*/
+        /* @var $renderer block_groups_renderer */
         $renderer = $PAGE->get_renderer('block_groups');
         // Calls Javascript if available.
         $PAGE->requires->js_call_amd('block_groups/blocks_groups_visibility', 'initialise', array($courseid));
@@ -145,7 +145,7 @@ class block_groups extends block_base
         $allgroups = groups_get_my_groups();
         // Necessary to show hidden groups to Course Managers.
         $access = has_capability('moodle/course:managegroups',  context_course::instance($COURSE->id));
-        /* @var $renderer block_groups_renderer*/
+        /* @var $renderer block_groups_renderer */
         $renderer = $PAGE->get_renderer('block_groups');
         foreach ($allgroups as $group) {
             if (($group->courseid == $COURSE->id)) {
@@ -174,7 +174,7 @@ class block_groups extends block_base
      */
     public function build_grouping_array($allgroupings, $courseid) {
         global $PAGE;
-        /* @var $renderer block_groups_renderer*/
+        /* @var $renderer block_groups_renderer */
         $renderer = $PAGE->get_renderer('block_groups');
         $groupingsarray = array();
         $arrayofmembers = count_grouping_members($courseid);


### PR DESCRIPTION
:exclamation: :exclamation: WIP :exclamation: :exclamation: 
travis.yml was changed to newer postgres and mysql version and moodle branches were added. 

When manually testing the plugin the following errors occurs only in Development mode :
```No cancel button found```
```No save button found```
```Modal is missing a footer region```
```Modal is missing a body region```
```Modal header is missing a title region```
```Modal is missing a header region```
```Container does not contain a modal```
```Element is not a modal container```
```Container does not contain a modal```
```Failed to pre-fetch the template: core/modal http://localhost/2finalmoodle36/lib/requirejs.php/1542020360/core/first.js l. 47```

it seems like moodle requires now the ModelFactory, the plugin needs to be adjusted to that. However, it does not affect the functionality, hiding and showing groups works. 