### PR TITLE
Fix external classes

### DIFF
--- a/classes/external/create_allgroups_output.php
+++ b/classes/external/create_allgroups_output.php
@@ -20,6 +20,9 @@ use core_external\external_function_parameters;
 use core_external\external_multiple_structure;
 use core_external\external_single_structure;
 use core_external\external_value;
+use context_course;
+use html_writer;
+use moodle_url;
 
 /**
  * create_allgroups_output external function
@@ -74,7 +77,7 @@ class create_allgroups_output extends \core_external\external_api {
      */
     public static function execute($groups) {
         global $PAGE, $CFG, $DB;
-        $params = self::validate_parameters(self::create_allgroups_output_parameters(), ['groups' => $groups]);
+        $params = self::validate_parameters(self::execute_parameters(), ['groups' => $groups]);
 
         require_once($CFG->dirroot . '/blocks/groups/locallib.php');
 

--- a/classes/external/create_output.php
+++ b/classes/external/create_output.php
@@ -20,6 +20,8 @@ use core_external\external_function_parameters;
 use core_external\external_multiple_structure;
 use core_external\external_single_structure;
 use core_external\external_value;
+use context_course;
+use moodle_url;
 
 /**
  * create_output external function
@@ -68,7 +70,7 @@ class create_output extends \core_external\external_api {
      */
     public static function execute($groups) {
         global $PAGE, $CFG, $DB;
-        $params = self::validate_parameters(self::create_output_parameters(), ['groups' => $groups]);
+        $params = self::validate_parameters(self::execute_parameters(), ['groups' => $groups]);
         $PAGE->set_context(context_course::instance($params['groups']['courseid']));
         require_capability('moodle/course:managegroups', context_course::instance($params['groups']['courseid']));
         require_once($CFG->dirroot . '/blocks/groups/locallib.php');


### PR DESCRIPTION
> **Note:** Please fill out all relevant sections and remove irrelevant ones.
### 🔀 Purpose of this PR:

- [x] Fixes a bug
- [ ] Updates for a new Moodle version
- [ ] Adds a new feature of functionality
- [ ] Improves or enhances existing features
- [ ] Refactoring: restructures code for better performance or maintainability
- [ ] Testing: add missing or improve existing tests
- [ ] Miscellaneous: code cleaning (without functional changes), documentation, configuration, ...

---

### 📝 Description:

Please describe the purpose of this PR in a few sentences.

  After the external function classes were refactored into namespaced classes, the execute() method in create_allgroups_output still referenced the old method name
  create_allgroups_output_parameters() instead of the renamed execute_parameters(), causing a fatal error when the external function was called. Additionally, the use statements for
   context_course, html_writer, and moodle_url were missing, which would cause class-not-found errors at runtime.

  - Bug: execute() called self::create_allgroups_output_parameters() (old name) instead of self::execute_parameters() (correct name after namespacing refactor), and three classes   
  were used without being imported.
  - Necessary because: The external API was broken after the namespacing changes introduced in the previous commits.                                                                 
  - After the fix: The external function resolves its parameters correctly and all referenced classes are properly imported. 

---

### 📋 Checklist

Please confirm the following (check all that apply):

- [ ] I have `phpunit` and/or `behat` tests that cover my changes or additions.
- [ ] Code passes the code checker without errors and warnings.
- [ ] Code passes the moodle-ci/cd pipeline on all supported Moodle versions or the ones the plugin supports.
- [x] Code does not have `var_dump()` or `var_export` or any other debugging statements (or commented out code) that
  should not appear on the productive branch.
- [x] Code only uses language strings instead of hard-coded strings.
- [x] If there are changes in the database: I updated/created the necessary upgrade steps in `db/upgrade.php` and
  updated the `version.php`.
- [x] If there are changes in javascript: I build new `.min` files with the `grunt amd` command.
- [ ] If it is a Moodle update PR: I read the release notes, updated the `version.php` and the `CHANGES.md`.
  I ran all tests thoroughly checking for errors. I checked if bootstrap had any changes/deprecations that require
  changes in the plugins UI.