### PR TITLE
Fix namespace imports in block groups

### DIFF
--- a/classes/output/renderer.php
+++ b/classes/output/renderer.php
@@ -17,6 +17,8 @@
 namespace block_groups\output;
 
 use plugin_renderer_base;
+use html_writer;
+use moodle_url;
 
 /**
  * Class of the block_groups renderer.


### PR DESCRIPTION
### 🔀 Purpose of this PR:

- [x] Fixes a bug
- [ ] Updates for a new Moodle version
- [ ] Adds a new feature of functionality
- [ ] Improves or enhances existing features
- [ ] Refactoring: restructures code for better performance or maintainability
- [ ] Testing: add missing or improve existing tests
- [ ] Miscellaneous: code cleaning (without functional changes), documentation, configuration, ...

---

### 📝 Description:

There was a bug where the URL class could not be found.
This happened because the namespace couldn't resolve the class correctly due to a missing backslash or import statement. To solve the errors that this was causing, the two imports `use html_writer;` and `use moodle_url;` have been added.

---

### 📋 Checklist

Please confirm the following (check all that apply):

- [x] I have `phpunit` and/or `behat` tests that cover my changes or additions.
- [x] Code passes the code checker without errors and warnings.
- [x] Code passes the moodle-ci/cd pipeline on all supported Moodle versions or the ones the plugin supports.
- [x] Code does not have `var_dump()` or `var_export` or any other debugging statements (or commented out code) that
  should not appear on the productive branch.
- [x] Code only uses language strings instead of hard-coded strings.
- [x] If there are changes in the database: I updated/created the necessary upgrade steps in `db/upgrade.php` and
  updated the `version.php`.
- [x] If there are changes in javascript: I build new `.min` files with the `grunt amd` command.
- [x] If it is a Moodle update PR: I read the release notes, updated the `version.php` and the `CHANGES.md`.
  I ran all tests thoroughly checking for errors. I checked if bootstrap had any changes/deprecations that require
  changes in the plugins UI.

---

### 🔍 Related Issues

- Related to #[IssueNumber]

---

### 🧾📸🌐 Additional Information (like screenshots, documentation, links, etc.)

Any other relevant information.

---