### PR TITLE
deletes now groups from the block_groups_hide table when deleted

### DIFF
--- a/classes/observers/group_observer.php
+++ b/classes/observers/group_observer.php
@@ -52,6 +52,12 @@ class group_observer {
         }
     }
 
+    /**
+     * Handles the group_deleted event.
+     * Automatically deletes the groups from the block_groups_hide table when a group itself has been deleted.
+     *
+     * @param \core\event\group_deleted $event
+     */
     public static function group_deleted(\core\event\group_deleted $event) {
         global $DB;
 

--- a/classes/observers/group_observer.php
+++ b/classes/observers/group_observer.php
@@ -51,4 +51,15 @@ class group_observer {
             $DB->insert_record_raw('block_groups_hide', ['id' => $groupid], true, false, true);
         }
     }
+
+    public static function group_deleted(\core\event\group_deleted $event) {
+        global $DB;
+
+        $groupid = $event->objectid;
+
+        // Remove the group from the block_groups_hide table if it exists.
+        if ($DB->record_exists('block_groups_hide', ['id' => $groupid])) {
+            $DB->delete_records('block_groups_hide', ['id' => $groupid]);
+        }
+    }
 }

--- a/classes/observers/group_observer.php
+++ b/classes/observers/group_observer.php
@@ -63,9 +63,7 @@ class group_observer {
 
         $groupid = $event->objectid;
 
-        // Remove the group from the block_groups_hide table if it exists.
-        if ($DB->record_exists('block_groups_hide', ['id' => $groupid])) {
-            $DB->delete_records('block_groups_hide', ['id' => $groupid]);
-        }
+        // Remove the group from the block_groups_hide table.
+        $DB->delete_records('block_groups_hide', ['id' => $groupid]);
     }
 }

--- a/db/events.php
+++ b/db/events.php
@@ -29,4 +29,8 @@ $observers = [
         'eventname' => '\core\event\group_created',
         'callback' => '\block_groups\observers\group_observer::group_created',
     ],
+    [
+        'eventname' => '\core\event\group_deleted',
+        'callback' => '\block_groups\observers\group_observer::group_deleted',
+    ],
 ];


### PR DESCRIPTION
> **Note:** Please fill out all relevant sections and remove irrelevant ones.
### 🔀 Purpose of this PR:

- [ ] Fixes a bug
- [ ] Updates for a new Moodle version
- [ ] Adds a new feature of functionality
- [x] Improves or enhances existing features
- [ ] Refactoring: restructures code for better performance or maintainability
- [ ] Testing: add missing or improve existing tests
- [ ] Miscellaneous: code cleaning (without functional changes), documentation, configuration, ...

---

### 📝 Description:

The issue was that in the block_groups_hide table, a group remained even after the group had been deleted. This led to stale entries referencing groups that no longer existed. To avoid this, deleted or invalid group references are now cleaned up, so the table only contains existing groups.

To enable this, an observer for the \core\event\group_deleted event was introduced. When this event is observed, the group will be removed from the table.

---

### 📋 Checklist

Please confirm the following (check all that apply):

- [x] I have `phpunit` and/or `behat` tests that cover my changes or additions.
- [x] Code passes the code checker without errors and warnings.
- [x] Code passes the moodle-ci/cd pipeline on all supported Moodle versions or the ones the plugin supports.
- [x] Code does not have `var_dump()` or `var_export` or any other debugging statements (or commented out code) that
  should not appear on the productive branch.
- [x] Code only uses language strings instead of hard-coded strings.
- [x] If there are changes in the database: I updated/created the necessary upgrade steps in `db/upgrade.php` and
  updated the `version.php`.
- [x] If there are changes in javascript: I build new `.min` files with the `grunt amd` command.
- [x] If it is a Moodle update PR: I read the release notes, updated the `version.php` and the `CHANGES.md`.
  I ran all tests thoroughly checking for errors. I checked if bootstrap had any changes/deprecations that require
  changes in the plugins UI.

---

### 🔍 Related Issues

- Related to #[13](https://github.com/learnweb/moodle-block_groups/issues/13)

---

### 🧾📸🌐 Additional Information (like screenshots, documentation, links, etc.)

Any other relevant information.

---